### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Infinite horizontal scrolling using `UICollectionView`
 
-[![Cocoapods Compatible](http://img.shields.io/cocoapods/v/InfiniteCollectionView.svg?style=flat)](http://cocoadocs.org/docsets/InfiniteCollectionView)
+[![CocoaPods Compatible](http://img.shields.io/cocoapods/v/InfiniteCollectionView.svg?style=flat)](http://cocoadocs.org/docsets/InfiniteCollectionView)
 [![Swift 2.0](https://img.shields.io/badge/Swift-2.0-orange.svg?style=flat)](https://developer.apple.com/swift/)
 
 <img src="https://github.com/hryk224/InfiniteCollectionView/wiki/images/sample1.gif" width="320" >
@@ -15,7 +15,7 @@ Infinite horizontal scrolling using `UICollectionView`
 
 ## install
 
-#### Cocoapods
+#### CocoaPods
 
 Adding the following to your `Podfile` and running `pod install`:
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
