### PR TITLE
Make the programmatic initializer public

### DIFF
--- a/InfiniteCollectionView/InfiniteCollectionView.swift
+++ b/InfiniteCollectionView/InfiniteCollectionView.swift
@@ -31,7 +31,7 @@ public class InfiniteCollectionView: UICollectionView {
         super.init(coder: aDecoder)
         configure()
     }
-    override init(frame: CGRect, collectionViewLayout layout: UICollectionViewLayout) {
+    override public init(frame: CGRect, collectionViewLayout layout: UICollectionViewLayout) {
         super.init(frame: frame, collectionViewLayout: layout)
         configure()
     }


### PR DESCRIPTION
Since the `init(frame:collectionViewLayout:)` initializer of UICollectionView had private access level, it was impossible to create an instance of `InfiniteCollectionView` programatically.
